### PR TITLE
TiledTileSet: fix numRows, numCols

### DIFF
--- a/flixel/addons/editors/tiled/TiledTileSet.hx
+++ b/flixel/addons/editors/tiled/TiledTileSet.hx
@@ -191,8 +191,8 @@ class TiledTileSet
 			
 			if (tileWidth > 0 && tileHeight > 0)
 			{
-				numRows = Std.int(imgWidth / tileWidth);
-				numCols = Std.int(imgHeight / tileHeight);
+				numRows = Std.int(imgHeight / tileHeight);
+				numCols = Std.int(imgWidth / tileWidth);
 				numTiles = numRows * numCols;
 			}
 		}


### PR DESCRIPTION
These two variables were named backwards. Dividing the image height by the tile height yields the number of rows, not columns, and dividing the image width by the tile width yields the number of columns, not rows. I know this is a breaking change, but I guess it has to be if we want the names to be correct.